### PR TITLE
Implement non-uniform rotation sampling for data simulation

### DIFF
--- a/src/cryojax_eo/commands/_simulate_data.py
+++ b/src/cryojax_eo/commands/_simulate_data.py
@@ -7,8 +7,8 @@ import sys
 
 import yaml
 
-from ..dataset import simulate_relion_dataset
-from ..internal import DatasetSimulatorConfig
+from cryojax_eo.dataset import simulate_relion_dataset
+from cryojax_eo.internal import DatasetSimulatorConfig
 
 
 def add_args(parser):

--- a/src/cryojax_eo/dataset/_relion_data_simulation.py
+++ b/src/cryojax_eo/dataset/_relion_data_simulation.py
@@ -321,12 +321,11 @@ def _make_particle_parameters(key: PRNGKeyArray, config: dict) -> dict:
     return relion_particle_parameters
 
 
-
-
 def _sample_vmf_rotation(mu: Float[Array, "3"], kappa: float, key: PRNGKeyArray) -> SO3:
     """
-    Samples from a von Mises–Fisher distribution (gaussian normalized to the sphere) for the out-of-plane direction
-    and a uniform in-plane rotation.
+    Samples non-uniform rotations.
+    Out-of-plane is sampled from a von Mises-Fisher distribution
+    In-plane is sampled from a uniform distribution.
     """
     key_dir, key_in_plane = jax.random.split(key)
 
@@ -366,8 +365,6 @@ def _sample_vmf_rotation(mu: Float[Array, "3"], kappa: float, key: PRNGKeyArray)
     R_in_plane = SO3.exp(in_plane_angle * out_of_plane_direction).as_matrix()
 
     return SO3.from_matrix((R_in_plane @ R_align).T)
-
-
 
 
 def _sample_non_uniform_mixutre_rotation(

--- a/src/cryojax_eo/dataset/_relion_data_simulation.py
+++ b/src/cryojax_eo/dataset/_relion_data_simulation.py
@@ -210,7 +210,21 @@ def _make_particle_parameters(key: PRNGKeyArray, config: dict) -> dict:
     # ... instantiate rotations
     key, subkey = jax.random.split(key)  # split the key to use for the next random number
 
-    rotation = SO3.sample_uniform(subkey)
+    rotations_config = config["rotations"]
+    if rotations_config["rotation_distribution"] == "uniform":
+        rotation = SO3.sample_uniform(subkey)
+    elif rotations_config["rotation_distribution"] == "non-uniform":
+        rotation = _sample_non_uniform_mixutre_rotation(
+            mu=rotations_config["vmf_mu"],
+            kappa=rotations_config["vmf_kappa"],
+            alpha=rotations_config["vmf_alpha"],
+            key=subkey,
+        )
+    else:
+        raise ValueError(
+            "Unknown rotation distribution. "
+            f"Got {rotations_config['rotation_distribution']}."
+        )
     key, subkey = jax.random.split(key)  # do this everytime you use a key!!
 
     # ... now in-plane translation
@@ -305,3 +319,65 @@ def _make_particle_parameters(key: PRNGKeyArray, config: dict) -> dict:
         "transfer_theory": transfer_theory,
     }
     return relion_particle_parameters
+
+
+
+
+def _sample_vmf_rotation(mu: Float[Array, "3"], kappa: float, key: PRNGKeyArray) -> SO3:
+    """
+    Samples from a von Mises–Fisher distribution (gaussian normalized to the sphere) for the out-of-plane direction
+    and a uniform in-plane rotation.
+    """
+    key_dir, key_in_plane = jax.random.split(key)
+
+    # Approximate concentrated directional sampling around `mu`.
+    mu_unit = mu / jnp.linalg.norm(mu)
+    x = mu_unit + jax.random.normal(key_dir, (3,)) / jnp.sqrt(kappa)
+    out_of_plane_direction = x / jnp.linalg.norm(x)
+
+    z_axis = jnp.array([0.0, 0.0, 1.0])
+    c = jnp.dot(z_axis, out_of_plane_direction)
+
+    def _align_z_to_direction() -> Float[Array, "3 3"]:
+        axis = jnp.cross(z_axis, out_of_plane_direction)
+        sin_theta = jnp.linalg.norm(axis)
+        axis_unit = axis / jnp.maximum(sin_theta, 1e-12)
+        kx, ky, kz = axis_unit
+        K = jnp.array([[0.0, -kz, ky], [kz, 0.0, -kx], [-ky, kx, 0.0]])
+        return jnp.eye(3) + sin_theta * K + (1.0 - c) * (K @ K)
+
+    # Handle numerically unstable cases (where \abs{v^T z} is close to 1)
+    R_align = jax.lax.cond(
+        c > 1.0 - 1e-7,
+        lambda _: jnp.eye(3),
+        lambda _: jax.lax.cond(
+            c < -1.0 + 1e-7,
+            lambda __: SO3.from_x_radians(jnp.pi).as_matrix(),
+            lambda __: _align_z_to_direction(),
+            operand=None,
+        ),
+        operand=None,
+    )
+
+    # Uniform in-plane angle around the chosen viewing direction.
+    in_plane_angle = jax.random.uniform(
+        key_in_plane, shape=(), minval=0.0, maxval=2.0 * jnp.pi
+    )
+    R_in_plane = SO3.exp(in_plane_angle * out_of_plane_direction).as_matrix()
+
+    return SO3.from_matrix((R_in_plane @ R_align).T)
+
+
+
+
+def _sample_non_uniform_mixutre_rotation(
+    mu: Float[Array, "3"], kappa: float, alpha: float, key: PRNGKeyArray
+) -> SO3:
+    """
+    Samples rotations from a mixture of non-uniform (vMF) and uniform rotations.
+    """
+    key_bernoulli, key_uniform, key_vmf = jax.random.split(key, 3)
+    use_vmf = jax.random.bernoulli(key_bernoulli, p=alpha)
+    uniform = SO3.sample_uniform(key_uniform)
+    vmf = _sample_vmf_rotation(mu, kappa, key_vmf)
+    return jax.lax.cond(use_vmf, lambda _: vmf, lambda _: uniform, operand=None)

--- a/src/cryojax_eo/internal/_config_validators/data_generator_config.py
+++ b/src/cryojax_eo/internal/_config_validators/data_generator_config.py
@@ -78,8 +78,11 @@ class DatasetSimulatorConfigRotations(BaseModel, extra="forbid"):
         default=0.5,
         ge=0.0,
         le=1.0,
-        description="Mixture weight between vMF and uniform rotations in [0, 1] - (1 means only vMF, 0 means only uniform)"
-        + "Only used if `rotation_distribution` is 'non-uniform'.",
+        description=(
+            "Mixture weight between vMF and uniform rotations in [0, 1] - "
+            "(1 means only vMF, 0 means only uniform). "
+            "Only used if `rotation_distribution` is 'non-uniform'."
+        ),
     )
 
     @field_validator("vmf_mu")
@@ -137,7 +140,7 @@ class DatasetSimulatorConfig(BaseModel, extra="forbid"):
     )
 
     rotations: dict = Field(
-        default_factory=lambda _ : dict(DatasetSimulatorConfigRotations().model_dump()),
+        default_factory=lambda _: dict(DatasetSimulatorConfigRotations().model_dump()),
         description="Rotation sampling configuration. Parsed by "
         + "`DatasetSimulatorConfigRotations`.",
     )

--- a/src/cryojax_eo/internal/_config_validators/data_generator_config.py
+++ b/src/cryojax_eo/internal/_config_validators/data_generator_config.py
@@ -57,6 +57,48 @@ class DatasetSimulatorConfigAtomicModels(BaseModel, extra="forbid"):
         return _validate_files_with_type(v, file_types=[".pdb", ".npz"])
 
 
+class DatasetSimulatorConfigRotations(BaseModel, extra="forbid"):
+    rotation_distribution: Literal["uniform", "non-uniform"] = Field(
+        default="uniform",
+        description="Distribution of particle rotations. "
+        + "'uniform' for uniform rotations; "
+        + "'non-uniform' for mixture of uniform and von Mises-Fisher rotations.",
+    )
+    vmf_kappa: PositiveFloat | list[PositiveFloat] = Field(
+        default=1.0,
+        description="Kappa parameter for the von Mises-Fisher distribution (1/variance)"
+        + "Only used if `rotation_distribution` is 'non-uniform'.",
+    )
+    vmf_mu: list[float] = Field(
+        default=[0.0, 0.0, 1.0],
+        description="Mean direction for the von Mises-Fisher distribution. "
+        + "Only used if `rotation_distribution` is 'non-uniform'.",
+    )
+    vmf_alpha: float = Field(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description="Mixture weight between vMF and uniform rotations in [0, 1] - (1 means only vMF, 0 means only uniform)"
+        + "Only used if `rotation_distribution` is 'non-uniform'.",
+    )
+
+    @field_validator("vmf_mu")
+    @classmethod
+    def validate_vmf_mu(cls, v):
+        arr = jnp.asarray(v, dtype=float)
+        if arr.shape != (3,):
+            raise ValueError("`rotations.vmf_mu` must be a 3-vector.")
+        norm = jnp.linalg.norm(arr)
+        if norm <= 0:
+            raise ValueError("`rotations.vmf_mu` must be non-zero.")
+        return arr
+
+    @field_serializer("vmf_mu")
+    def serialize_vmf_mu(self, v):
+        arr = jnp.asarray(v, dtype=float)
+        return arr / jnp.linalg.norm(arr)
+
+
 class DatasetSimulatorConfig(BaseModel, extra="forbid"):
     """
     Parameters for the data generation pipeline.
@@ -92,6 +134,12 @@ class DatasetSimulatorConfig(BaseModel, extra="forbid"):
     )
     offset_y_in_angstroms: float | list[float] = Field(
         0.0, description="Offset in y direction in Angstroms."
+    )
+
+    rotations: dict = Field(
+        default_factory=lambda _ : dict(DatasetSimulatorConfigRotations().model_dump()),
+        description="Rotation sampling configuration. Parsed by "
+        + "`DatasetSimulatorConfigRotations`.",
     )
 
     # Transfer Theory
@@ -172,6 +220,11 @@ class DatasetSimulatorConfig(BaseModel, extra="forbid"):
         else:
             v = jnp.array(v)
         return v
+
+    @field_serializer("rotations")
+    @classmethod
+    def serialize_rotations(cls, v):
+        return dict(DatasetSimulatorConfigRotations(**v).model_dump())
 
     @field_serializer("defocus_in_angstroms")
     def serialize_defocus_in_angstroms(self, v):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -17,6 +17,7 @@ from cryojax_eo.internal import DatasetSimulatorConfig
 
 @pytest.fixture
 def sample_simulator_config(
+    sample_rotations_config,
     sample_path_to_pdb1,
     sample_path_to_pdb2,
 ):
@@ -56,7 +57,24 @@ def sample_simulator_config(
         images_per_file=10,
         batch_size_for_generation=10,
         overwrite=True,
+        rotations=sample_rotations_config,
     )
+
+
+@pytest.fixture(
+    params=[
+        {},  # Uniform by default
+        {
+            "rotation_distribution": "non-uniform",
+            "vmf_kappa": 3.0,
+            "vmf_mu": [0.0, 0.0, 1.0],
+            "vmf_alpha": 0.5,
+        },
+    ],
+    ids=["uniform-rotations", "non-uniform-rotations"],
+)
+def sample_rotations_config(request):
+    return request.param
 
 
 def test_make_relion_parameter_file(sample_simulator_config):


### PR DESCRIPTION
- Implement non-uniform rotation sampling with a mixture of von Mises–Fisher and unifrom distributions.
- Update DatasetSimulatorConfig with a rotation config.