### PR TITLE
Changed field to data_params in suggested config files

### DIFF
--- a/docs/ensemble_optimization.md
+++ b/docs/ensemble_optimization.md
@@ -13,7 +13,7 @@ Cryo-EM Ensemble Optimization uses a custom YAML input format. A sample [config 
 ```yaml
 # Parameters marked with (*) are optional
 
-dataset_params:
+data_params:
   path_to_relion_project: /path/to/relion/project/
   path_to_starfile: /path/to/starfile.star
   loads_envelope: True # (*) Default: false, loads envelope function parameters

--- a/docs/ensemble_reweighting.md
+++ b/docs/ensemble_reweighting.md
@@ -20,7 +20,7 @@ Cryo-EM Ensemble Reweighting uses a custom YAML input format. A sample [config f
 ```yaml
 # Parameters marked with (*) are optional
 
-dataset_params:
+data_params:
   path_to_relion_project: /path/to/relion/project/
   path_to_starfile: /path/to/starfile.star
   loads_envelope: True # (*) Default: false, loads envelope function parameters

--- a/docs/example_configs/config_reweighting.yaml
+++ b/docs/example_configs/config_reweighting.yaml
@@ -1,4 +1,4 @@
-dataset_params:
+data_params:
   path_to_relion_project: /path/to/relion/project/
   path_to_starfile: /path/to/starfile.star
   loads_envelope: True # (*) Default: false, loads envelope function parameters


### PR DESCRIPTION
This is a fix I made to address a pydantic error for expecting `data_params` as a naming convention.

It was motivated by an error like


```
pydantic_core._pydantic_core.ValidationError: 2 validation errors for ReweightingConfig
data_params
  Field required [type=missing, input_value={'dataset_params': {'path...'loads_b_factors': True}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.13/v/missing
dataset_params
  Extra inputs are not permitted [type=extra_forbidden, input_value={'path_to_relion_project'...cryosparc_adjusted.mrc'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.13/v/extra_forbidden
```

This is my personal attempt at fixing issue #115 